### PR TITLE
Nhúng phần mô tả vào trang chủ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -210,3 +210,14 @@ span.user {
 .users.follow {
   padding: 0;
 }
+
+.frame {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0 none;
+  box-sizing: border-box;
+}

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -24,6 +24,6 @@
   </div>
 <% else %>
   <div class="center">
-    <h1>Welcome to the VNUTimetables</h1>
+    <iframe src="https://danhmanh.github.io/se02-vnu-student" class="frame"></iframe>
   </div>
 <% end %>


### PR DESCRIPTION
Khi chưa đăng nhập, người dùng sẽ thấy giới thiệu về trang web ở trang chủchủ như sau:
![screenshot from 2019-01-09 21-40-13](https://user-images.githubusercontent.com/40811995/50906238-3f67fa80-1457-11e9-9775-d2320b3d3791.png)
![screenshot from 2019-01-09 21-40-23](https://user-images.githubusercontent.com/40811995/50906239-3f67fa80-1457-11e9-9625-41915b1b7064.png)
![screenshot from 2019-01-09 21-40-36](https://user-images.githubusercontent.com/40811995/50906240-40009100-1457-11e9-8c2f-9867019b341b.png)
